### PR TITLE
Added AF_AUTO mode to Camera1

### DIFF
--- a/library/src/main/api14/com/google/android/cameraview/Camera1.java
+++ b/library/src/main/api14/com/google/android/cameraview/Camera1.java
@@ -443,6 +443,8 @@ class Camera1 extends CameraViewImpl {
             final List<String> modes = mCameraParameters.getSupportedFocusModes();
             if (autoFocus && modes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
                 mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+            } else if (autoFocus && modes.contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
+                mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
             } else if (modes.contains(Camera.Parameters.FOCUS_MODE_FIXED)) {
                 mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_FIXED);
             } else if (modes.contains(Camera.Parameters.FOCUS_MODE_INFINITY)) {


### PR DESCRIPTION
Added AF_AUTO instead of FIXED AF as failover if CONTINUOUS AF is not supported.
This issue originates from google/cameraview and explains why we often have blurry images on shity devices (e.g., Samsung J1). Images were previously taken at FIXED_FOCUS at a random focus distance.