### PR TITLE
Autofocus huawei p9 fix

### DIFF
--- a/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
+++ b/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
@@ -237,6 +237,7 @@ public class MainActivity extends AppCompatActivity implements
         @Override
         public void onCameraOpened(CameraView cameraView) {
             Log.d(TAG, "onCameraOpened");
+            cameraView.setAutoFocus(true);
         }
 
         @Override

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,7 +78,7 @@ uploadArchives {
                 name 'CameraView'
                 groupId 'com.leo_pharma'
                 artifactId 'cameraview'
-                version '1.0'
+                version '1.1'
                 packaging 'aar'
                 description 'The LEO iLab fork of CameraView.'
                 url 'https://github.com/leoilab/cameraview'

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -679,7 +679,7 @@ class Camera2 extends CameraViewImpl {
     private void lockFocus(){
         try {
             mCaptureSession.stopRepeating();
-            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
+            mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_IDLE);
             mCaptureCallback.setState(PictureCaptureCallback.STATE_FOCUS_REQUEST);
             mPreviewRequestBuilder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
             mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_MACRO);


### PR DESCRIPTION
The manually triggered auto-focused is now initialized with a trigger setting, so it no longer fails silently in transitioning auto-focus mode.

When changing from continuous auto-focus (`CONTROL_AF_MODE_CONTINUOUS_PICTURE`
) to manually triggered auto-focus (`CONTROL_AF_MODE_AUTO` / `CONTROL_AF_MODE_MACRO`) the trigger **MUST** be in the idle state (`CONTROL_AF_TRIGGER_IDLE`).
If not, the transition to manually triggered auto-focus fails silently and the library will wait in an infinite loop for the camera to transition state.

Here what the docs say:

public static final int `CONTROL_AF_TRIGGER_CANCEL` = Autofocus will return to its initial state, and cancel any currently active trigger.
public static final int `CONTROL_AF_TRIGGER_IDLE` = The trigger is idle.

See: https://developer.android.com/reference/android/hardware/camera2/CaptureRequest

See https://github.com/leoilab/imagine-rn/issues/1563