### PR TITLE
Minimal solution for Camera2 null pointer exception

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,7 +78,7 @@ uploadArchives {
                 name 'CameraView'
                 groupId 'com.leo_pharma'
                 artifactId 'cameraview'
-                version '1.1'
+                version '1.2'
                 packaging 'aar'
                 description 'The LEO iLab fork of CameraView.'
                 url 'https://github.com/leoilab/cameraview'


### PR DESCRIPTION
Solves NPE caused by a race between taking a picture and switching camera.
Here the `CameraCaptureSession` becomes `NULL` while the `CameraDevice`
is restarted. This is resolved by a simple check if the
`CameraCaptureSession` is available on capture.
If not the picture is taken if the `CameraCaptureSession`
becomes available within 2000ms.

I have decided against changing the lifecycle logic (waiting for the
`CameraCaptureSession` in order to restart the `CameraDevice`), as this
is a more complex solution and therefore more likely to produce errors.

See: https://github.com/leoilab/imagine-rn/issues/1778