### PR TITLE
Introducing a `onCaptureFailed` callback.

### DIFF
--- a/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
+++ b/demo/src/main/java/com/google/android/cameraview/demo/MainActivity.java
@@ -89,18 +89,7 @@ public class MainActivity extends AppCompatActivity implements
 
     private Handler mBackgroundHandler;
 
-    private View.OnClickListener mOnClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View v) {
-            switch (v.getId()) {
-                case R.id.take_picture:
-                    if (mCameraView != null) {
-                        mCameraView.takePicture();
-                    }
-                    break;
-            }
-        }
-    };
+    private FloatingActionButton mTakePictureButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -111,9 +100,17 @@ public class MainActivity extends AppCompatActivity implements
             mCameraView.addCallback(mCallback);
             mCameraView.setAutoFocus(true);
         }
-        FloatingActionButton takePicture = (FloatingActionButton) findViewById(R.id.take_picture);
-        if (takePicture != null) {
-            takePicture.setOnClickListener(mOnClickListener);
+        mTakePictureButton = (FloatingActionButton) findViewById(R.id.take_picture);
+        if (mTakePictureButton != null) {
+            mTakePictureButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mCameraView != null) {
+                        mTakePictureButton.setVisibility(View.INVISIBLE);
+                        mCameraView.takePicture();
+                    }
+                }
+            });
         }
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -126,6 +123,7 @@ public class MainActivity extends AppCompatActivity implements
     @Override
     protected void onResume() {
         super.onResume();
+        mTakePictureButton.setVisibility(View.VISIBLE);
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
                 == PackageManager.PERMISSION_GRANTED) {
             mCameraView.start();
@@ -248,6 +246,7 @@ public class MainActivity extends AppCompatActivity implements
         @Override
         public void onPictureTaken(CameraView cameraView, final byte[] data) {
             Log.d(TAG, "onPictureTaken " + data.length);
+            mTakePictureButton.setVisibility(View.VISIBLE);
             Toast.makeText(cameraView.getContext(), R.string.picture_taken, Toast.LENGTH_SHORT)
                     .show();
             getBackgroundHandler().post(new Runnable() {
@@ -275,6 +274,12 @@ public class MainActivity extends AppCompatActivity implements
             });
         }
 
+        @Override
+        public void onCaptureFailed(CameraView cameraView, String message) {
+            Toast.makeText(cameraView.getContext(), message, Toast.LENGTH_LONG)
+                    .show();
+            mTakePictureButton.setVisibility(View.VISIBLE);
+        }
     };
 
     public static class ConfirmationDialogFragment extends DialogFragment {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,7 +78,7 @@ uploadArchives {
                 name 'CameraView'
                 groupId 'com.leo_pharma'
                 artifactId 'cameraview'
-                version '1.2'
+                version '1.3'
                 packaging 'aar'
                 description 'The LEO iLab fork of CameraView.'
                 url 'https://github.com/leoilab/cameraview'

--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -110,9 +110,13 @@ class Camera2 extends CameraViewImpl {
             // If we have a pending capture requests process it.
             if (mTakePictureOnReadyCaptureSession) {
                 mTakePictureOnReadyCaptureSession = false;
-                if (System.currentTimeMillis() - mTakePictureOnReadyTimestamp <=
-                        TAKE_PICTURE_TIME_OUT_MS) {
+                long currentTime = System.currentTimeMillis();
+                if (currentTime - mTakePictureOnReadyTimestamp <= TAKE_PICTURE_TIME_OUT_MS) {
                     takePicture();
+                }
+                else {
+                    mCallback.onCaptureFailed("Capture request did timeout after: " +
+                            (currentTime - mTakePictureOnReadyTimestamp) + " ms");
                 }
             }
         }

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -86,6 +86,7 @@ abstract class CameraViewImpl {
 
         void onPictureTaken(byte[] data);
 
+        void onCaptureFailed(String message);
     }
 
 }

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -491,6 +491,13 @@ public class CameraView extends FrameLayout {
             }
         }
 
+        @Override
+        public void onCaptureFailed(String message) {
+            for (Callback callback : mCallbacks) {
+                callback.onCaptureFailed(CameraView.this, message);
+            }
+        }
+
         public void reserveRequestLayoutOnOpen() {
             mRequestLayoutOnOpen = true;
         }
@@ -584,6 +591,15 @@ public class CameraView extends FrameLayout {
          * @param data       JPEG data.
          */
         public void onPictureTaken(CameraView cameraView, byte[] data) {
+        }
+
+        /**
+         * Called when a picture capture has failed.
+         *
+         * @param cameraView The associated {@link CameraView}.
+         * @param message    A string describing the reason for failing.
+         */
+        public void onCaptureFailed(CameraView cameraView, String message) {
         }
     }
 


### PR DESCRIPTION
When capture fails (e.g., timeout on `CameraCaptureSession`), we can now
propagate the error, to the application to re-enable the capture button.

